### PR TITLE
Make it check once a second for changes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,8 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script>
+        var current_date;
+
         function loadFile(timeStamp) {
             var text = {};
             $.ajaxSetup({
@@ -30,6 +32,13 @@
         }
         function startTime() {
             var today = new Date();
+            if(current_date !== undefined
+                && current_date.getMinutes() === today.getMinutes() ) {
+                var t = setTimeout(startTime, 1000);
+                return;
+            }
+
+            current_date = today;
             var h = today.getHours();
             var m = today.getMinutes();
             // var s = today.getSeconds();
@@ -70,7 +79,7 @@
             }
 
             // Timeout
-            var t = setTimeout(startTime, 60000);
+            var t = setTimeout(startTime, 1000);
         }
         function checkTime(i) {
             if (i < 10) { i = "0" + i };  // add zero in front of numbers < 10


### PR DESCRIPTION
Previously, if you loaded the clock at 8:00:55, it would tell you the wrong time for the vast majority of that minute.

If it doesn't detect a change in what minute it is, it doesn't update the quote, otherwise it does. 