### PR TITLE
Fix incorrect quote split at 22:01

### DIFF
--- a/docs/times/22_01.json
+++ b/docs/times/22_01.json
@@ -17,9 +17,9 @@
   },
   {
     "time": "22:01",
-    "quote_first": "I could not doubt that this was the BLACK SPOT; and taking it up, I found writ",
+    "quote_first": "I could not doubt that this was the BLACK SPOT; and taking it up, I found written on the other side, in a very good, clear hand, this short message: \"You have till ",
     "quote_time_case": "ten",
-    "quote_last": " on the other side, in a very good, clear hand, this short message: \"You have till ten tonight.\"",
+    "quote_last": " tonight.\"",
     "title": "Treasure Island",
     "author": "Robert Louis Stevenson"
   },


### PR DESCRIPTION
The quote split happens around `ten`, which was found early in the quote as the second half of `written`, splitting the quote up incorrectly.