### PR TITLE
Add dark theme support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,13 @@
         function init() {
             // This code runs only at page load
 
+            // Try to guess theme preference
+            if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                dark_theme();
+            } else {
+                light_theme();
+            }
+
             // Check if sfw query parameter passed
             var queries = new URLSearchParams(window.location.search);
             var sfw = queries.has('sfw') && ['yes', 'true', '1'].includes(queries.get('sfw').toLowerCase());
@@ -130,6 +137,7 @@
     </script>
     <link rel="stylesheet" href="styles.css">
     <link href='https://fonts.googleapis.com/css?family=Merriweather' rel='stylesheet'>
+    <script src="theme.js"></script>
 
     <title>Literature Clock</title>
 
@@ -163,6 +171,9 @@
         </span>
         <span id="sfw_toggle">
             <a href="/?sfw=yes">Skip quotes marked NSFW</a>
+        </span>
+        <span>
+            <a id="toggle-theme" onclick="toggle_theme()" href="#">Dark Theme</a>
         </span>
     </div>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -58,3 +58,20 @@ cite #book{
     border-left-width: 2px;
     border-left-color: dimgray;
 }
+
+/* dark theme */
+body.dark {
+    background: #181A1B;
+}
+
+body.dark #lit_quote em {
+    color: rgb(220, 217, 212);
+}
+
+body.dark #main_text, body.dark #buttom {
+    color: rgb(166, 158, 146);
+}
+
+body.dark #buttom a, a:visited {
+    color: rgb(190, 185, 176);
+}

--- a/docs/theme.js
+++ b/docs/theme.js
@@ -1,0 +1,19 @@
+function dark_theme() {
+    document.body.classList.add('dark');
+    localStorage.theme = 'dark';
+    document.getElementById('toggle-theme').innerText = 'Light Theme';
+}
+
+function light_theme() {
+    document.body.classList.remove('dark');
+    localStorage.theme = 'light';
+    document.getElementById('toggle-theme').innerText = 'Dark Theme';
+}
+
+function toggle_theme() {
+    if (localStorage.theme === 'dark') {
+        light_theme();
+    } else {
+        dark_theme();
+    }
+}


### PR DESCRIPTION
Some users (such as myself) prefer a darker colour scheme. I use this page as my homepage so I look at it a lot.
The current solution is to use a browser extension to inject CSS.
Since this page has a very simple structure, it is trivial to add CSS rules manually.